### PR TITLE
create custom AC newsletter signup form

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -47,6 +47,18 @@ const Detail = styled.div`
   flex-direction: row;
   width: 100%;
   justify-content: space-between;
+  align-items: center;
+
+  ${below.med`
+    flex-direction: column;
+    align-items: center;
+  `};
+`;
+
+const StyledNewsletterSignUpForm = styled(NewsletterSignUpForm)`
+  ${below.med`
+    margin-top: 3rem;
+  `};
 `;
 
 const Footer = ({ className }) => {
@@ -80,7 +92,7 @@ const Footer = ({ className }) => {
               <NavLink href="/">Other Policies</NavLink>
             </FooterNavColumn>
           </FooterNav>
-          <NewsletterSignUpForm title="Join our community, sign up for our newsletter" />
+          <StyledNewsletterSignUpForm title="Join our community, sign up for our newsletter" />
         </Detail>
       </ContentSection>
       <PageFooter />
@@ -96,7 +108,6 @@ export default styled(Footer)`
   background-color: ${({ theme }) => theme.colors.offWhite};
 
   ${below.med`
-    flex-direction: column;
     min-height: 33rem;
   `};
 `;

--- a/components/HomePage/NewsletterSignup.js
+++ b/components/HomePage/NewsletterSignup.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { Grid, Cell } from 'styled-css-grid';
 import ContentSection from '../shared/ContentSection';
 import NewsletterSignUpForm from '../shared/NewsletterSignupForm';
 import { below } from '../../utilities';
@@ -13,6 +12,12 @@ const HighlightImage = styled.img`
   transform: scaleX(-1);
   object-fit: cover;
   height: 100%;
+
+  ${below.large`
+    max-height: 22rem;
+    object-fit: contain;
+    margin-top: 1.5rem;
+  `};
 `;
 
 const Main = styled.div`
@@ -31,6 +36,16 @@ const SideDetail = styled.div`
   flex-direction: column;
   margin-right: 2rem;
   width: 30vw;
+
+  ${below.large`
+    width: 70vw;
+    align-self: flex-start;
+  `};
+
+  ${below.small`
+    width: 90%;
+    align-self: flex-start;
+  `};
 `;
 
 const NewsletterSignUp = ({ className }) => {
@@ -38,7 +53,11 @@ const NewsletterSignUp = ({ className }) => {
     <ContentSection className={className} id="newsletter-signup">
       <Main>
         <SideDetail>
-          <NewsletterSignUpForm title="Join our community, sign up for our newsletter" />
+          <NewsletterSignUpForm
+            headerType="h3"
+            title="Join our community<br/>sign up for our newsletter"
+            subtitle="Sign up for secrets, poetry, theories on black holes, and other important conference info, dates and inspiration."
+          />
         </SideDetail>
         <HighlightImage src="/images/bear_with_megaphone.png" />
       </Main>

--- a/components/shared/NewsletterSignupForm.js
+++ b/components/shared/NewsletterSignupForm.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import { textInputs } from 'polished';
+import SquareButton from './SquareButton';
 
 const FormContainer = styled.div`
   display: flex;
@@ -9,71 +9,103 @@ const FormContainer = styled.div`
   justify-content: center;
 `;
 
-const ActiveCampaignForm = styled.form`
-  ._form-content {
-    display: flex;
-    width: 100%;
-
-    ._form_element {
-      flex-grow: 2;
-    }
-  }
-
-  input {
-    min-width: 100%;
-  }
-
-  button {
-    visibility: hidden;
-
-    &:after {
-      content: '';
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewbox='0 0 30 30' transform='rotate(-90)' fill='white'><path d='M12,16c-0.3,0-0.5-0.1-0.7-0.3L5.2,9.6C4.8,9.2,4.9,8.6,5.3,8.2c0.4-0.3,0.9-0.3,1.3,0l5.4,5.4l5.4-5.4 c0.4-0.4,1.1-0.3,1.4,0.1c0.3,0.4,0.3,0.9,0,1.3l-6.1,6.1C12.5,15.9,12.3,16,12,16z' /></svg>");
-      background-repeat: no-repeat;
-      visibility: visible;
-      background-color: ${({ theme }) => theme.colors.thatBlue};
-      color: ${({ theme }) => theme.colors.white};
-      padding: 1rem;
-      border: none;
-      margin-left: 1rem;
-      display: block;
-      height: 3.75rem;
-      width: 3.75rem;
-      position: relative;
-      top: -2.3rem;
-      background-position: center;
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-`;
-
 const Title = styled.h5`
   text-transform: uppercase;
   margin: 0;
+  margin-bottom: 0.7rem;
+  color: ${({ theme }) => theme.colors.fonts.dark};
 `;
 
-const InputsRow = styled.div``;
+const Subtitle = styled.p`
+  margin: 0;
+  line-height: 1.2;
+  margin: 0.7rem 0 1.4rem 0;
+`;
+
+const InputsRow = styled.div`
+  width: 100%;
+  display: flex;
+
+  input {
+    flex-grow: 2;
+    margin-right: 0.7rem;
+  }
+`;
+
+const ThankYouBlock = styled.p`
+  margin: 0;
+  line-height: 1.4;
+  text-align: center;
+`;
 
 class NewsletterSignUpForm extends Component {
-  componentDidMount() {
-    const script = document.createElement('script');
+  constructor(props) {
+    super(props);
 
-    script.src = 'https://thatconference.activehosted.com/f/embed.php?id=16';
-    script.async = true;
+    this.state = {
+      formSubmitted: false,
+    };
 
-    document.body.appendChild(script);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  onSubmit(event) {
+    event.preventDefault();
+    const data = new FormData(event.target);
+
+    fetch('https://thatconference.activehosted.com/proc.php', {
+      method: 'POST',
+      body: data,
+      mode: 'no-cors',
+    })
+      .then(response => {
+        this.setState({ formSubmitted: true });
+        setTimeout(() => {
+          this.setState({ formSubmitted: false });
+        }, 5000);
+      })
+      .catch(error => console.log('Request failed', error));
   }
 
   render() {
+    const { formSubmitted } = this.state;
+    const { className, headerType, style, subtitle, title } = this.props;
+
     return (
-      <FormContainer className={this.props.className}>
-        <Title>{this.props.title}</Title>
-        <InputsRow>
-          <ActiveCampaignForm className="_form_16" />
-        </InputsRow>
+      <FormContainer className={className} style={style}>
+        <Title as={headerType} dangerouslySetInnerHTML={{ __html: title }} />
+
+        {subtitle && <Subtitle>{subtitle}</Subtitle>}
+
+        {formSubmitted && (
+          <ThankYouBlock>
+            <strong>THANK YOU</strong> for joining our mailing list!
+            <br />
+            Check your inbox for a confirmation.
+          </ThankYouBlock>
+        )}
+
+        {!formSubmitted && (
+          <form onSubmit={this.onSubmit}>
+            <input type="hidden" name="u" value="16" />
+            <input type="hidden" name="f" value="16" />
+            <input type="hidden" name="s" />
+            <input type="hidden" name="c" value="0" />
+            <input type="hidden" name="m" value="0" />
+            <input type="hidden" name="act" value="sub" />
+            <input type="hidden" name="v" value="2" />
+
+            <InputsRow>
+              <input
+                type="text"
+                name="email"
+                placeholder="ex: hello@youareawesome.com"
+                required
+              />
+              <SquareButton icon="arrow" iconClass="right" />
+            </InputsRow>
+          </form>
+        )}
       </FormContainer>
     );
   }

--- a/styles/globalStyle.js
+++ b/styles/globalStyle.js
@@ -35,6 +35,7 @@ const GlobalStyle = createGlobalStyle`
   h4, h5 {
     font-family: franklin-gothic-urw, sans-serif;
     color: ${({ theme }) => theme.colors.fonts.dark};
+    line-height: 1.4;
   }
 
   h1 {


### PR DESCRIPTION
Changes included:
- ditches the embedded AC form so we can roll our own
- updates styles for both newsletter components to better stack on mobile
- fix text and styling for homepage newsletter signup section within page
- signup for newsletter now keeps you on page (no redirecting or going through AC)

Along with this change I updated the confirmation email from AC:
- to send from hello@that instead of sara@that
- updated format to include new logo and colors
- added social icons

### MOBILE
![image](https://user-images.githubusercontent.com/82035/68087598-7ca5da80-fe25-11e9-91d7-5408ea589f4e.png)
![image](https://user-images.githubusercontent.com/82035/68087835-2d60a980-fe27-11e9-9f4f-efd8874a69f2.png)


### DESKTOP
![image](https://user-images.githubusercontent.com/82035/68087649-f2aa4180-fe25-11e9-82b4-109386d5f109.png)
![image](https://user-images.githubusercontent.com/82035/68087821-128e3500-fe27-11e9-82f5-b5a75c5b0cad.png)

### Thank you message after sign up
![image](https://user-images.githubusercontent.com/82035/68087714-3735dd00-fe26-11e9-93df-047a13e2b653.png)

### AC confirmation email
![image](https://user-images.githubusercontent.com/82035/68087739-6d735c80-fe26-11e9-9072-e01d12dda957.png)

Fixes #61 