### PR TITLE
Get campers using grid and flowing properly

### DIFF
--- a/components/HomePage/MeetCampers.js
+++ b/components/HomePage/MeetCampers.js
@@ -5,7 +5,7 @@ import ContentSection from '../shared/ContentSection';
 import LinkButton from '../shared/LinkButton';
 import ProfileItem from '../shared/ProfileItem';
 
-import { below, DEFAULT_WIP_PAGE } from '../../utilities';
+import { gridRepeat, DEFAULT_WIP_PAGE } from '../../utilities';
 
 const CAMPERS = [
   {
@@ -70,22 +70,8 @@ const CAMPERS = [
   },
 ];
 
-const ProfileRow = styled.div`
-  display: flex;
-  margin: auto;
-  justify-content: center;
-  flex-wrap: wrap;
-`;
-
 const TitleRow = styled.div`
-  display: flex;
-  flex-direction: row;
   padding-bottom: 2rem;
-  align-items: center;
-
-  ${below.small`
-    flex-direction: column;
-  `};
 `;
 
 const Header = styled.h3`
@@ -117,19 +103,22 @@ const MeetCampers = ({ className }) => {
           />
         </div>
       </TitleRow>
-      <ProfileRow>
+        <Grid columns={gridRepeat.xxsmall} alignContent="center">
+
         {CAMPERS.map((item, index) => {
           return (
-            <ProfileItem
-              imageUrl={item.imageUrl}
-              size="100"
-              titleSize="1.4"
-              name={item.name}
-              key={index}
-            />
+            <Cell >
+              <ProfileItem
+                imageUrl={item.imageUrl}
+                titleSize="1.4"
+                size="100"
+                name={item.name}
+                key={index}
+              />
+            </Cell>
           );
         })}
-      </ProfileRow>
+        </Grid>
     </ContentSection>
   );
 };


### PR DESCRIPTION
Leaves enough space for the long names, now uses the styled-css-grid rather than custom flexbox. 

Only 1 commit, but depends on #89 so that's included at this time. 

<img width="595" alt="Screen Shot 2019-11-12 at 10 33 39 PM" src="https://user-images.githubusercontent.com/240650/68733509-83a6b880-059c-11ea-83e2-82b205acf2c7.png">
<img width="817" alt="Screen Shot 2019-11-12 at 10 33 25 PM" src="https://user-images.githubusercontent.com/240650/68733510-83a6b880-059c-11ea-9baa-46a22d922479.png">
<img width="1180" alt="Screen Shot 2019-11-12 at 10 33 16 PM" src="https://user-images.githubusercontent.com/240650/68733511-83a6b880-059c-11ea-9537-99f83e20cdc5.png">
