### PR TITLE
add simple feature/page toggle

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,4 @@
 SENTRY_DSN=
+
+# Keyword used to lock down a component so that has a matching query param
+FEATURE_KEYWORD=

--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ THAT Website utilizes `styled-components`. `1rem` = `10px`
 ## Tests
 
 We utilize Jest + Enzyme to unit test each component. Each component should be covered with a spec to ensure it renders without error as well any additional functions that component relies on to render correctly.
+
+## Feature/Page Development
+
+In order to iterate collectivlely when developing a new page we have a higher order component you can wrap your page component around so that it is only rendered for a matching query param.
+
+Here is how it works, in your `.env` file give `FEATURE_KEYWORD` some value. Then wrap your page componet (_NOTE: currently only works for pages_) in `togglePage`. This adds the logic that will allow this page to render **only when** a query param is present and matches the value set in `FEATURE_KEYWORD`.
+
+Example - Let's say the speakers page is wrapped in `togglePage`. Set FEATURE_KEYWORD to a value, let's go with `baconisgreat`, then fire up the local environment.
+Go to: http://localhost:3000/wi/speakers?feature=baconisgreat and page will load.
+Go to: http://localhost:3000/wi/speakers?feature=baconisgood, page not found
+Go to: http://localhost:3000/wi/speakers, page not found

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In order to iterate collectivlely when developing a new page we have a higher or
 
 Here is how it works, in your `.env` file give `FEATURE_KEYWORD` some value. Then wrap your page componet (_NOTE: currently only works for pages_) in `togglePage`. This adds the logic that will allow this page to render **only when** a query param is present and matches the value set in `FEATURE_KEYWORD`.
 
-Example - Let's say the speakers page is wrapped in `togglePage`. Set FEATURE_KEYWORD to a value, let's go with `baconisgreat`, then fire up the local environment.
-Go to: http://localhost:3000/wi/speakers?feature=baconisgreat and page will load.
-Go to: http://localhost:3000/wi/speakers?feature=baconisgood, page not found
-Go to: http://localhost:3000/wi/speakers, page not found
+Example - Check out `samples/toggle-page.js`. Here is a sample page wrapped in `togglePage`. Now, set FEATURE_KEYWORD in your `.env` to a value, let's go with `baconisgreat`, then fire up the local environment.
+Go to: http://localhost:3000/samples/toggle-page?feature=baconisgreat and page will load.
+Go to: http://localhost:3000/samples/toggle-page?feature=baconisgood, page not found
+Go to: http://localhost:3000/samples/toggle-page, page not found

--- a/pages/samples/toggle-page.js
+++ b/pages/samples/toggle-page.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Head from 'next/head';
+import togglePage from '../../utilities/togglePage';
+
+import ContentSection from '../../components/shared/ContentSection';
+
+const TogglePage = () => {
+  return (
+    <>
+      <Head>
+        <title key="title">Sample Toggle Page - THAT Conference</title>
+      </Head>
+
+      <ContentSection>
+        <h1>Sample Toggle Page</h1>
+        <p>
+          This page demonstrates how to use the togglePage HOC so that we can
+          iterate on new feature/page development without introducing the page
+          to the site until we are ready.
+        </p>
+      </ContentSection>
+    </>
+  );
+};
+
+export default togglePage(TogglePage);

--- a/pages/wi/speakers.js
+++ b/pages/wi/speakers.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Head from 'next/head';
+import togglePage from '../../utilities/togglePage';
+
+import ContentSection from '../../components/shared/ContentSection';
+
+const speakers = () => {
+  return (
+    <>
+      <Head>
+        <title key="title">Speakers - THAT Conference</title>
+      </Head>
+
+      <ContentSection>
+        <h1>Speakers</h1>
+      </ContentSection>
+    </>
+  );
+};
+
+export default togglePage(speakers);

--- a/utilities/togglePage.js
+++ b/utilities/togglePage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Error from '../pages/_error';
+
+export default WrappedComponent =>
+  class extends React.Component {
+    static async getInitialProps({ query: { feature } }) {
+      if (feature === process.env.FEATURE_KEYWORD) {
+        return {};
+      }
+      return { statusCode: 404 };
+    }
+
+    render() {
+      const { statusCode } = this.props;
+      if (statusCode) {
+        return <Error statusCode={statusCode} />;
+      }
+      return <WrappedComponent props={this.props} />;
+    }
+  };

--- a/utilities/togglePage.js
+++ b/utilities/togglePage.js
@@ -15,6 +15,6 @@ export default WrappedComponent =>
       if (statusCode) {
         return <Error statusCode={statusCode} />;
       }
-      return <WrappedComponent props={this.props} />;
+      return <WrappedComponent {...this.props} />;
     }
   };


### PR DESCRIPTION
Adds a HOC that we can use to wrap a page that will check to see if query param given matches value set in `.env` then page can be displayed; if not sends user to page not found.

Example - speakers page added is wrapped in `togglePage`. Set `FEATURE_KEYWORD` to say `baconisgreat`. Fire up the local environment. 
Go to: http://localhost:3000/wi/speakers?feature=baconisgreat and page will load. 
Go to: http://localhost:3000/wi/speakers?feature=baconisgood, page not found
Go to: http://localhost:3000/wi/speakers, page not found

We can use this to wrap any page in that we want to lock down while we develop out. 

Not full feature toggle ability but a start to get us to 1/1.