### PR TITLE
Fix for Issue #138

### DIFF
--- a/components/shared/ContentSection.js
+++ b/components/shared/ContentSection.js
@@ -35,20 +35,9 @@ const Trees = styled.img`
   top: -8rem;
   z-index: 10;
   width: 17rem;
-  left: 44vw;
+  left: 50%;
+  margin-left:8.5rem;
   overflow: visible;
-
-  ${below.med`
-    left: 40vw;
-  `};
-
-  ${below.small`
-    left: 35vw;
-  `};
-
-  ${below.xsmall`
-    left: 27vw;
-  `};
 `;
 
 const ContentSection = ({


### PR DESCRIPTION
I've tested this only in the browser inspector. But it should work. Viewport widths are going to track with the viewport (browser) at all times. Setting widths and positioning to percentages will be influenced by and constrained by the html elements, allowing the logo to stay centered with other elements on the page, not the browser window.