### PR TITLE
only grabbing session when in ssr mode

### DIFF
--- a/lib/withApolloClient.js
+++ b/lib/withApolloClient.js
@@ -20,7 +20,11 @@ export default App => {
       let appProps = {};
       let currentUser = {};
 
-      currentUser = await auth0.getSession(ctx.ctx.req);
+      if (typeof window === 'undefined') {
+        dlog('in ssr mode, getting users session');
+        currentUser = await auth0.getSession(ctx.ctx.req);
+      }
+
       dlog('currentUser %o', currentUser);
 
       if (App.getInitialProps) {


### PR DESCRIPTION
added a window check before calling getSession to make sure we were in SSR mode.

fixes #175