### PR TITLE
Added a more resilient way to center the Trees within the Content

### DIFF
--- a/components/shared/ContentSection.js
+++ b/components/shared/ContentSection.js
@@ -35,20 +35,8 @@ const Trees = styled.img`
   top: -8rem;
   z-index: 10;
   width: 17rem;
-  left: 44vw;
+  left: calc(50vw - 8.5rem);
   overflow: visible;
-
-  ${below.med`
-    left: 40vw;
-  `};
-
-  ${below.small`
-    left: 35vw;
-  `};
-
-  ${below.xsmall`
-    left: 27vw;
-  `};
 `;
 
 const ContentSection = ({


### PR DESCRIPTION
Instead of setting different (responsive) breakpoints to get the tree to be centered, I used a calculation of 50% the view-width minus 1/2 of the tree's width. 

`calc(50vw - 8.5rem)` 

This will give you true-center in all screen resolutions.

Fixes #138 
