### PR TITLE
Disable the eslint rule to warn on unescaped HTML entities

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,13 @@
 {
-  "extends": ["airbnb", "plugin:prettier/recommended", "prettier/react"],
+  "extends": [
+    "airbnb",
+    "plugin:prettier/recommended",
+    "prettier/react"
+  ],
   "parser": "babel-eslint",
-  "parserOptions": { "ecmaVersion": 8 },
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "env": {
     "browser": true,
     "commonjs": true,
@@ -15,7 +21,20 @@
     "no-nested-ternary": "off",
     "react/prop-types": "off",
     "react/jsx-props-no-spreading": "off",
-    "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }]
+    "react/no-unescaped-entities": "off",
+    "react/jsx-filename-extension": [
+      "error",
+      {
+        "extensions": [
+          ".js",
+          ".jsx"
+        ]
+      }
+    ]
   },
-  "plugins": ["jest", "react-hooks", "prettier"]
+  "plugins": [
+    "jest",
+    "react-hooks",
+    "prettier"
+  ]
 }


### PR DESCRIPTION
Having escaped HTML entities in JS files makes reading copy harder to grok. Chatted about this with the team and am disabling the rule. If we break stuff because of it, we can turn it back on and be more selective on it.