### PR TITLE
Removed HTML entities from the Call for Counselors area.

### DIFF
--- a/components/CallForCounselors/Perks.js
+++ b/components/CallForCounselors/Perks.js
@@ -70,7 +70,7 @@ const GetStartedNow = styled(LinkButton)`
 const Perks = ({ featureKeyword }) => {
   return (
     <Main>
-      <Title>Perks If You&apos;re Selected To Speak At THAT Conference</Title>
+      <Title>Perks If You're Selected To Speak At THAT Conference</Title>
       <Container>
         <Perk>
           <PerkImage src="/images/what_to_expect_hands_on_learning.png" />

--- a/components/CallForCounselors/Process.js
+++ b/components/CallForCounselors/Process.js
@@ -83,7 +83,7 @@ const Process = ({ featureKeyword, milestones }) => {
               THAT Conference is a professional polyglot technical conference
               that also has a rich experience for children and other family
               members. Your session could be aimed at the professional track or
-              for family &quot;geeklings&quot;.
+              for family "geeklings".
             </p>
           </ProcessBlock>
           <ProcessBlock>
@@ -91,9 +91,9 @@ const Process = ({ featureKeyword, milestones }) => {
               Standard Sessions
             </ProcessAndDatesSubHeading>
             <p>
-              60 minutes total including time for answering questions.
-              There&apos;s a 30 minute break in between each session to nuture
-              those all important hallway conversations.
+              Standard sessions are 60 minutes each, including time for
+              answering questions. There is a 30 minute break in-between each
+              session to nurture those all important hallway conversations.
             </p>
           </ProcessBlock>
           <ProcessBlock>
@@ -103,7 +103,7 @@ const Process = ({ featureKeyword, milestones }) => {
             <p>
               Half day (four hours) or full day (8 hours). The day before the
               main conference is set aside for a full day of workshops. Be
-              prepared to provide attendees a decent agenda for what you&apos;ll
+              prepared to provide attendees a decent agenda for what you'll
               cover.
             </p>
           </ProcessBlock>
@@ -111,10 +111,10 @@ const Process = ({ featureKeyword, milestones }) => {
             <ProcessAndDatesSubHeading>Keynotes</ProcessAndDatesSubHeading>
             <p>
               Do you have what it takes to give a 90 minute speech on something
-              you&apos;re passionate about? You&apos;ll have an audience of over
-              1,000 people in front of the stage listening to your story. We
-              want topics that&apos;ll motivate, energize, and help attendees
-              see the world differently as the diverse place it is.
+              you're passionate about? You'll have an audience of over 1,000
+              people in front of the stage listening to your story. We want
+              topics that'll motivate, energize, and help attendees see the
+              world differently as the diverse place it is.
             </p>
           </ProcessBlock>
         </Cell>

--- a/components/CounselorAgreement/Acknowledgment.js
+++ b/components/CounselorAgreement/Acknowledgment.js
@@ -78,7 +78,7 @@ const Achknowledgment = ({ featureKeyword }) => {
               />
             </div>
           </div>
-          <FormSubmit label="Agree &amp; Continue" />
+          <FormSubmit label="Agree and Continue" />
         </Form>
       )}
     </Formik>

--- a/components/CounselorAgreement/WhatsProvided.js
+++ b/components/CounselorAgreement/WhatsProvided.js
@@ -11,8 +11,8 @@ const Agreement = () => {
         </li>
         <li>
           A full ticket to the conference (with pre-conference), including
-          pre-conference lunch, breakfast & lunch during the conference, and the
-          pig roast party.
+          pre-conference lunch, breakfast and lunch during the conference, and
+          the pig roast party.
         </li>
         <li>
           Geekling and Campmate tickets for one additional adult and up to two

--- a/components/CounselorStart/Header.js
+++ b/components/CounselorStart/Header.js
@@ -17,7 +17,7 @@ const TopParagraph = styled.p`
 const Header = ({ featureKeyword }) => {
   return (
     <>
-      <Title>Let&apos;s Get Started</Title>
+      <Title>Let's Get Started</Title>
       <TopParagraph>
         We’re stoked to hear you’re interested in speaking at THAT Conference!
         Being a counselor is more than just showing up, giving a talk, and


### PR DESCRIPTION
Now that we have removed the eslint rule for HTML entities, I have updated the copy for several files so they are easier to read.