### PR TITLE
add redirect option to login

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@zeit/next-source-maps": "0.0.3",
     "apollo-boost": "^0.4.7",
     "apollo-link-context": "^1.0.19",
+    "base64url": "^3.0.1",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "flat": "^5.0.0",

--- a/pages/api/callback.js
+++ b/pages/api/callback.js
@@ -1,14 +1,23 @@
 import debug from 'debug';
 import * as Sentry from '@sentry/browser';
-
+import base64url from 'base64url';
 import auth0 from '../../lib/auth0';
 
 const dlog = debug('that:api:callback');
 
 export default async function callback(req, res) {
+  const state = base64url.toBuffer(req.query.state || '');
+  const sep = state.indexOf('|');
+  let redirect2 =
+    sep > 0 && state.length - sep - 1 === 32
+      ? state.toString('utf8', 0, sep)
+      : '/';
+  if (redirect2.toLocaleLowerCase().match(/http/g)) {
+    redirect2 = '/';
+  }
   try {
     dlog('auth0 callback executed');
-    await auth0.handleCallback(req, res, { redirectTo: '/' });
+    await auth0.handleCallback(req, res, { redirectTo: redirect2 });
   } catch (error) {
     dlog('callback errored: %o', error);
 

--- a/pages/api/login.js
+++ b/pages/api/login.js
@@ -1,14 +1,25 @@
 import debug from 'debug';
 import * as Sentry from '@sentry/browser';
-
+import { randomBytes } from 'crypto';
+import base64url from 'base64url';
 import auth0 from '../../lib/auth0';
 
 const dlog = debug('that:api:login');
 
 export default async function login(req, res) {
+  const redirectUrl = req.query['redirect-url'] || '/';
+  const state = Buffer.concat([
+    Buffer.from(redirectUrl),
+    Buffer.from('|'),
+    randomBytes(32),
+  ]);
   try {
     dlog('user logging in');
-    await auth0.handleLogin(req, res);
+    await auth0.handleLogin(req, res, {
+      authParams: {
+        state: base64url(state),
+      },
+    });
   } catch (error) {
     dlog('login errored: %o', error);
     Sentry.captureException(error);


### PR DESCRIPTION
Add `/api/login?redirect-url=<path> ` to login page to redirect back to that path after authentication. 
Only use a path value. Any redirects to a domain will result being redirected to `/`