### PR TITLE
Help text added below the Mobile Phone field on the Member Profile

### DIFF
--- a/components/Member/Profile/ContactInfo.js
+++ b/components/Member/Profile/ContactInfo.js
@@ -166,7 +166,7 @@ const ContactInfoForm = ({
           errors={errors}
           touched={touched}
           label="Mobile Phone"
-          placeholder="ex: +10001110000"
+          helpText="Enter like: +10001110000"
         />
       </FormRow>
       <FlexFormRow>


### PR DESCRIPTION
Added help text below the Mobile Phone field on the Member Profile contact information screen.

'What would be helpful to see' from Issue #287 is satisfied with this addition.