### PR TITLE
add bottom THAT nav for general items

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -79,6 +79,30 @@ const Footer = () => {
           </a>
           <FooterNav>
             <FooterNavColumn>
+              <Title>THAT</Title>
+              <NavLink href="/about" onClick={() => clickTracking('about')}>
+                About
+              </NavLink>
+              <NavLink href="/contact" onClick={() => clickTracking('contact')}>
+                Contact
+              </NavLink>
+              <NavLink href="/blog" onClick={() => clickTracking('blog')}>
+                Blog
+              </NavLink>
+              <NavLink
+                href="/wi/tickets"
+                onClick={() => clickTracking('tickets')}
+              >
+                Tickets
+              </NavLink>
+              <NavLink
+                href="/wi/partners"
+                onClick={() => clickTracking('partners')}
+              >
+                Partners
+              </NavLink>
+            </FooterNavColumn>
+            <FooterNavColumn>
               <Title>Resources</Title>
               <NavLink href="/wi/faq" onClick={() => clickTracking('faq')}>
                 FAQ
@@ -108,24 +132,6 @@ const Footer = () => {
                 Family Handbook
               </NavLink>
             </FooterNavColumn>
-            {/* <FooterNavColumn>
-              <Title>Plan Your Trip</Title>
-              <NavLink
-                href="/"
-                onClick={() => clickTracking('important dates')}
-              >
-                Important Dates
-              </NavLink>
-              <NavLink href="/" onClick={() => clickTracking('travel info')}>
-                Travel Information
-              </NavLink>
-              <NavLink href="/" onClick={() => clickTracking('handbook')}>
-                Handbooks
-              </NavLink>
-              <NavLink href="/" onClick={() => clickTracking('faq')}>
-                FAQ
-              </NavLink>
-            </FooterNavColumn> */}
             <FooterNavColumn>
               <Title>Policies</Title>
               <NavLink

--- a/components/Header/Nav.js
+++ b/components/Header/Nav.js
@@ -49,6 +49,13 @@ const Nav = ({ className, mobileMenuOpen, onClick }) => {
           </NavListItem>
           <NavListItem>
             <NavItem
+              title="Tickets"
+              href="/wi/tickets"
+              onClick={() => onClick(false)}
+            />
+          </NavListItem>
+          <NavListItem>
+            <NavItem
               title="Plan Your Trip"
               href="/wi/plan-your-trip"
               onClick={() => onClick(false)}
@@ -69,7 +76,7 @@ const Nav = ({ className, mobileMenuOpen, onClick }) => {
           <NavListItem>
             <NavItem
               title="Contact"
-              href="/wi/contact"
+              href="/contact"
               onClick={() => onClick(false)}
             />
           </NavListItem>

--- a/pages/about.js
+++ b/pages/about.js
@@ -42,6 +42,7 @@ const HighlightImage = styled.img`
   ${below[twoColBp]`
     margin-left: auto;
     margin-right: auto;
+    min-width: 30rem;
   `};
 
   ${above[twoColBp]`

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -2,13 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { Grid, Cell } from 'styled-css-grid';
 import Head from 'next/head';
-import { below } from '../../utilities/breakpoint';
+import { below } from '../utilities/breakpoint';
 
-import ContentSection from '../../components/shared/ContentSection';
-import ImageContainer from '../../components/shared/ImageContainer';
-import LinkButton from '../../components/shared/LinkButton';
+import ContentSection from '../components/shared/ContentSection';
+import ImageContainer from '../components/shared/ImageContainer';
+import LinkButton from '../components/shared/LinkButton';
 
-import { gridRepeat } from '../../utilities';
+import { gridRepeat } from '../utilities';
 
 const StyledImageContainer = styled(ImageContainer)`
   padding: 2.5rem;

--- a/pages/wi/plan-your-trip.js
+++ b/pages/wi/plan-your-trip.js
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import { useQuery } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';
 import moment from 'moment';
-import { below, DEFAULT_WIP_PAGE, gridRepeat } from '../../utilities';
+import { below, gridRepeat } from '../../utilities';
 
 import ContentSection from '../../components/shared/ContentSection';
 import ImageContainer from '../../components/shared/ImageContainer';
@@ -136,7 +136,7 @@ const contact = () => {
               {formattedEndDate}
             </p>
             <LinkButton
-              href={`/${DEFAULT_WIP_PAGE}`}
+              href="/wi/tickets"
               label="Ticket Options"
               borderColor="thatBlue"
               color="thatBlue"


### PR DESCRIPTION
- add tickets to top nav
- move contacts to root page
- wire up tickets link to plan your trip page
- add bottom nav (more to do here as we sire up speakers and schedule, but a start to get some at the bottom)

![Plan_Your_Trip_-_THAT_Conference](https://user-images.githubusercontent.com/82035/73138722-ff5cc100-4033-11ea-9981-2c0797cff593.png)

![Plan_Your_Trip_-_THAT_Conference](https://user-images.githubusercontent.com/82035/73138729-13a0be00-4034-11ea-96db-0ef4ce6d7210.png)

