### PR TITLE
removing the people section until we have the memembers area sorted out

### DIFF
--- a/components/HomePage/SponsorHighlight.js
+++ b/components/HomePage/SponsorHighlight.js
@@ -126,7 +126,11 @@ const SponsorHighlight = ({ className, eventSlug }) => {
             <FeaturedPartners>
               <PartnerTitle>Our Featured Camp Partners</PartnerTitle>
               {partners.map(s => (
-                <Link href="/wi/partner/[slug]" as={`/wi/partner/${s.slug}`}>
+                <Link
+                  key={s.id}
+                  href="/wi/partner/[slug]"
+                  as={`/wi/partner/${s.slug}`}
+                >
                   <PartnerLogo
                     src={s.companyLogo}
                     alt={s.companyName}

--- a/pages/wi/index.js
+++ b/pages/wi/index.js
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 
 import Hero from '../../components/HomePage/Hero';
 import LearnMore from '../../components/HomePage/LearnMore';
-import MeetCampers from '../../components/HomePage/MeetCampers';
+// import MeetCampers from '../../components/HomePage/MeetCampers';
 import SpeakerHighlight from '../../components/HomePage/SpeakerHighlight';
 import TimelineSection from '../../components/HomePage/Timeline';
 import SponsorHighlight from '../../components/HomePage/SponsorHighlight';
@@ -83,7 +83,7 @@ const home = () => {
       <SponsorHighlight eventSlug="/wi" />
       <Testimonials />
       <NewsletterSignup />
-      <MeetCampers />
+      {/* <MeetCampers /> */}
       <BottomImage src="./images/mess-hall.jpg" loading="lazy" />
 
       <script


### PR DESCRIPTION
Right now I'm hiding the member section. It was meant to showcase everyone in the community and we got the layout working with ourselves. 

Going to hide it for now until we flip the member bits. 