### PR TITLE
Changed the href on the Featured Camp Partner logo to point to /partner/[slug]

### DIFF
--- a/components/HomePage/SponsorHighlight.js
+++ b/components/HomePage/SponsorHighlight.js
@@ -128,8 +128,8 @@ const SponsorHighlight = ({ className, eventSlug }) => {
               {partners.map(s => (
                 <Link
                   key={s.id}
-                  href="/wi/partner/[slug]"
-                  as={`/wi/partner/${s.slug}`}
+                  href="/partner/[slug]"
+                  as={`/partner/${s.slug}`}
                 >
                   <PartnerLogo
                     src={s.companyLogo}


### PR DESCRIPTION
.. instead of /wi/partner/[slug], which was resulting in a "Page Not Found" error being displayed.

This corrects #371.