### PR TITLE
force footer to bottom of short content page

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -20,7 +20,7 @@ const CorePage = styled.div`
   height: 100vh;
   width: 100vw;
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto;
   grid-gap: 0;
 `;
 
@@ -35,7 +35,6 @@ const InnerPage = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 2;
-  min-height: 100%;
 `;
 
 const Page = ({ children, headerType }) => {


### PR DESCRIPTION
This also resolves issue noticed in FireFox where on these short content pages, footer was off the screen and forced a scroll.

Fixes #390