### PR TITLE
Add redirects for past sessions and speakers

### DIFF
--- a/now.json
+++ b/now.json
@@ -24,5 +24,17 @@
       "CURRENT_EVENT_ID": "ByE7Dc7eCGcRFzLhWhuI"
     }
   },
-  "regions": ["cle"]
+  "regions": ["cle"],
+  "redirects": [
+    {
+      "source": "/sessions/(.*)",
+      "destination": "https://old.thatconference.com/sessions/$1",
+      "statusCode": 302
+    },
+    {
+      "source": "/speakers/(.*)",
+      "destination": "https://old.thatconference.com/speakers/$1",
+      "statusCode": 302
+    }
+  ]
 }


### PR DESCRIPTION
redirects requests to root /sessions, and /speakers to the old website. 

POC Examples:
https://nextdump.brettski.now.sh/sessions/session/14010
https://nextdump.brettski.now.sh/speakers/speaker/adrhart
