### PR TITLE
rollback for PR443.  Fixing Horizontal scroll broke logo

### DIFF
--- a/components/Footer/PageFooter.js
+++ b/components/Footer/PageFooter.js
@@ -31,7 +31,7 @@ const Footer = ({ className }) => {
 
 export default styled(Footer)`
   padding: 1.7rem;
-  width: 100%;
+  width: 100vw;
   background-color: ${({ theme }) => theme.colors.primary};
   font-size: 1.2rem;
   line-height: 1.2;

--- a/components/Header/MessageBar.js
+++ b/components/Header/MessageBar.js
@@ -85,7 +85,7 @@ const MessageBar = ({ className, user, loading, notifications }) => {
 };
 
 export default styled(MessageBar)`
-  width: 100%;
+  width: 100vw;
   background-color: ${({ theme }) => theme.colors.primary};
   position: fixed;
   z-index: 20;

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -230,7 +230,7 @@ export default styled(Header)`
   padding: 0 0 2rem 0;
   background-color: transparent;
   z-index: 1;
-  width: 100%;
+  width: 100vw;
 
   position: ${({ layered }) => (layered ? 'absolute' : 'relative')};
 

--- a/components/Page.js
+++ b/components/Page.js
@@ -22,7 +22,7 @@ const StyledPage = styled.div`
 
 const CorePage = styled.div`
   height: 100vh;
-  width: 100%;
+  width: 100vw;
   display: grid;
   grid-template-rows: auto;
   grid-gap: 0;
@@ -35,7 +35,7 @@ const PageDiv = styled.div`
 `;
 
 const InnerPage = styled.div`
-  width: 100%;
+  width: 100vw;
   display: flex;
   flex-direction: column;
   flex-grow: 2;

--- a/components/shared/ContentSection.js
+++ b/components/shared/ContentSection.js
@@ -14,11 +14,10 @@ const Container = styled.div`
       : props.theme.colors.fonts.dark};
   position: relative;
   display: block;
-  width: 100%;
+  width: 100vw;
 
   ${below.xsmall`
     padding: 5rem 1rem;
-    width: 100vw;
   `}
 `;
 

--- a/pages/wi/index.js
+++ b/pages/wi/index.js
@@ -57,7 +57,7 @@ const GET_EVENT = gql`
 
 const BottomImage = styled.img`
   object-fit: cover;
-  width: 100%;
+  width: 100vw;
   height: 45rem;
 `;
 


### PR DESCRIPTION
The original PR #433 while addressing #308 and #68 ended up causing #453 and possibly #454 

After talking with @csell5 about it, I tried to fix the Logo issue of #453.  In doing so, the problem was not repeatable in a dev build locally.  Clark attempted to get me setup to use the production build locally which caused a different issue with GraphQL.  He looked at his setup and was seeing the same thing.

So, further discussion led to this PR to rollback the original changes from PR #433.  This will fix the Logo issue, may fix the mobile footer issue, but will also re-introduce the Horizontal scrolling issues.  It was deemed that the horizontal scrolling was the lesser of two evils.

I will be adding a new Issue linking and addressing the appropriate items.

Sorry for the headache.
