### PR TITLE
fix media query size for content section to accommodate big phones

### DIFF
--- a/components/shared/ContentSection.js
+++ b/components/shared/ContentSection.js
@@ -16,7 +16,7 @@ const Container = styled.div`
   display: block;
   width: 100%;
 
-  ${below.xsmall`
+  ${below.small`
     padding: 5rem 1rem;
     width: 100vw;
   `}


### PR DESCRIPTION
Fixes #456 

After fixing horizontal scrolling it was noticed that iPhone Max was now not working.  Issue was on ContentSection media query.  Adjust widths was done on xsmall and changed to small.

