### PR TITLE
fixed linkedin link to public url

### DIFF
--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -180,7 +180,7 @@ export const socialConstants = {
     medium: 'https://medium.com/that-conference',
     youtube: 'https://www.youtube.com/thatconference/',
     flickr: 'https://www.flickr.com/photos/thatconference/',
-    linkedin: 'https://www.linkedin.com/company/25065729/admin/',
+    linkedin: 'https://www.linkedin.com/company/that-conference',
     github: 'https://github.com/ThatConference',
   }),
 


### PR DESCRIPTION
Simple update to use correct linkedin url in our social references