### PR TITLE
Fixed Link issue

### DIFF
--- a/components/Header/MessageBar.js
+++ b/components/Header/MessageBar.js
@@ -37,7 +37,7 @@ const LinkContainer = styled.span`
 `;
 
 const getLinkForEnvironment = url => {
-  if (process.env.NODE_ENV === 'development')
+  if (process.env.NODE_ENV !== 'production')
     return url.replace('www.thatconference.com', 'localhost:3000');
   return url;
 };


### PR DESCRIPTION
The blog link (Refactoring THAT Conference 2020) in Home Page Header Bar was redirecting to Localhost.

Fixed the issue!