### PR TITLE
Potential fix for 450 No Header on No Partner

### DIFF
--- a/components/PartnerDetail/HeroSection.js
+++ b/components/PartnerDetail/HeroSection.js
@@ -127,8 +127,8 @@ const HeroSection = ({
             hoverBorderColor="white"
             hoverColor="primary"
             hoverBackgroundColor="white"
-            target="blank"
-            isLocal={false}
+            target={connectWithUsUrl.startsWith('/') ? '' : 'blank'}
+            isLocal={connectWithUsUrl.startsWith('/')}
           />
           <DownArrow icon="arrow" />
         </div>

--- a/pages/partner/[slug].js
+++ b/pages/partner/[slug].js
@@ -212,35 +212,48 @@ const getCityState = ({ partner }) => {
 };
 
 const CompanyNotFound = () => (
-  <ContentSection
-    style={{
-      minHeight: '100vh',
-      display: 'flex',
-      alignContent: 'center',
-    }}
-  >
-    <h2>Not Yet a THAT Partner</h2>
-    <ActionButtonRow>
-      <LinkButton
-        href="/wi/become-a-partner"
-        label="Become a Partner"
-        color="thatBlue"
-        borderColor="thatBlue"
-        hoverBorderColor="thatBlue"
-        hoverColor="white"
-        hoverBackgroundColor="thatBlue"
-      />
-      <LinkButton
-        href="/partners"
-        label="View Past Partners"
-        color="thatBlue"
-        borderColor="thatBlue"
-        hoverBorderColor="thatBlue"
-        hoverColor="white"
-        hoverBackgroundColor="thatBlue"
-      />
-    </ActionButtonRow>
-  </ContentSection>
+  <MainDiv>
+    <HeroSection
+      companyName="Not Yet A THAT Partner"
+      heroImageUrl=""
+      connectWithUsUrl="/wi/become-a-partner"
+      location="wi"
+    />
+    <ContentSection
+      style={{
+        display: 'flex',
+        alignContent: 'center',
+      }}
+    >
+      <p className="large-body-copy">
+        We believe that by partnering with our sponsors not only can we help
+        enable your goals but it also creates a more engaging environment for
+        for our attendees. Engage with true practitioners, thought leaders and
+        entrepreneurs while enjoying the perks of summer camp at a giant
+        waterpark. Join us and become part of THAT family.
+      </p>
+      <ActionButtonRow>
+        <LinkButton
+          href="/wi/become-a-partner"
+          label="Become a Partner"
+          color="thatBlue"
+          borderColor="thatBlue"
+          hoverBorderColor="thatBlue"
+          hoverColor="white"
+          hoverBackgroundColor="thatBlue"
+        />
+        <LinkButton
+          href="/partners"
+          label="View Past Partners"
+          color="thatBlue"
+          borderColor="thatBlue"
+          hoverBorderColor="thatBlue"
+          hoverColor="white"
+          hoverBackgroundColor="thatBlue"
+        />
+      </ActionButtonRow>
+    </ContentSection>
+  </MainDiv>
 );
 
 function PartnerDetail() {


### PR DESCRIPTION
Fix #450 

This is a potential solution that didn't involve changing the headerType of the page.  Text was borrowed from elsewhere on the site.

1. Add hero image (default)
2. Company Name is "Not Yet a THAT Parter"
3. Connect with Us link -> Become a Partner page in same tab.  If real parnter, continue using new tab
4. Text underneath taken from Top of Become a Partner Page