### PR TITLE
Resolve 488 - Don't Initialize LogRocket for local dev

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,8 +14,11 @@ import Page from '../components/Page';
 Router.events.on('routeChangeComplete', url => gtag.pageview(url));
 
 Sentry.init(getSentryConfig());
-LogRocket.init(process.env.LOG_ROCKET);
-
+if (process.env.NODE_ENV !== 'development') {
+  // only initialize LogRocket in non-dev environments
+  // https://docs.logrocket.com/docs/development#using-logrocket-in-development
+  LogRocket.init(process.env.LOG_ROCKET);
+}
 class MyApp extends App {
   render() {
     const { Component, pageProps, apolloClient, err } = this.props;


### PR DESCRIPTION
resolves #488 

Using https://docs.logrocket.com/docs/development#using-logrocket-in-development as a guide.