### PR TITLE
fix social object structure for use with SocialLinks.js

### DIFF
--- a/components/shared/PartnerLogoWithInfo.js
+++ b/components/shared/PartnerLogoWithInfo.js
@@ -53,12 +53,12 @@ const PartnerLogoWithInfo = ({ alignment, partner, className }) => {
   const getPartnerSocialLinks = () => {
     const socials = {};
 
-    if (partner.facebook) socials.facebook = partner.facebook;
-    if (partner.twitter) socials.twitter = partner.twitter;
-    if (partner.instagram) socials.instagram = partner.instagram;
-    if (partner.youtube) socials.youtube = partner.youtube;
-    if (partner.linkedin) socials.linkedin = partner.linkedIn;
-    if (partner.github) socials.github = partner.github;
+    if (partner.facebook) socials.facebook = { url: partner.facebook };
+    if (partner.twitter) socials.twitter = { url: partner.twitter };
+    if (partner.instagram) socials.instagram = { url: partner.instagram };
+    if (partner.youtube) socials.youtube = { url: partner.youtube };
+    if (partner.linkedIn) socials.linkedin = { url: partner.linkedIn };
+    if (partner.github) socials.github = { url: partner.github };
 
     return socials;
   };


### PR DESCRIPTION
fix linkin reference, fix social object structure for use with SocialLinks.js

LinkedIn not showing for any parter
No links working for parter.

Turns out object being created was in the wrong for for the component using it. Updated creation of object for partner page.