### PR TITLE
styling fixes and changed p to pre

### DIFF
--- a/components/shared/JobListing.js
+++ b/components/shared/JobListing.js
@@ -139,7 +139,7 @@ const JobListing = ({ job, partner }) => {
             onClick={() => setExpandedDescription(!expandedDescription)}
             className="show-more"
           >
-            {`Show ${expandedDescription ? 'Less' : 'More'}`}
+            {`Show ${expandedDescription ? 'Less ' : 'More '}`}
           </ShowMore>
         )}
       </JobDetail>

--- a/components/shared/StandardStyles.js
+++ b/components/shared/StandardStyles.js
@@ -128,6 +128,8 @@ export const ShowMore = styled.p`
   text-align: right;
 
   &:hover {
+    cursor: pointer;
+    filter: brightness(10%);
     fill: ${({ theme }) => theme.colors.highlight};
   }
 `;

--- a/pages/partner/[slug]/job/[jobSlug].js
+++ b/pages/partner/[slug]/job/[jobSlug].js
@@ -249,7 +249,7 @@ const jobDetail = () => {
                 </AttributeTag>
               )}
             </AttributesRow>
-            <p className="medium-body-copy">{job.description}</p>
+            <pre className="medium-body-copy">{job.description}</pre>
             <ActionButtonRow>
               <LinkButton
                 href={`/partner/${partner.slug}`}

--- a/pages/wi/2021/jobs.js
+++ b/pages/wi/2021/jobs.js
@@ -108,6 +108,10 @@ const PartnerSection = styled.div`
   padding-bottom: 4rem;
 
   &:not(:first-child) {
+    padding-top: 4rem;
+  }
+
+  &:not(:last-child) {
     border-bottom: 1px solid ${({ theme }) => theme.colors.mediumGray};
   }
 
@@ -119,6 +123,11 @@ const PartnerSection = styled.div`
 const StyledPartnerLogoWithInfo = styled(PartnerLogoWithInfo)`
   max-width: 27rem;
   flex-grow: 1;
+
+  img {
+    max-width: 27rem;
+    padding-bottom: 0;
+  }
 
   ${below.large`
     max-width: unset;
@@ -142,17 +151,17 @@ const jobs = () => {
   return (
     <>
       <NextSeo
-        title="WI 2020 Jobs - THAT Conference"
+        title="WI 2021 Jobs - THAT Conference"
         description="Job openings for all WI 2020 THAT partners"
       />
 
       <ContentSection>
         <Main>
           <SideDetail>
-            <h1>THAT WI 2020 - Partner Jobs</h1>
+            <h1>THAT WI 2021 - Partner Jobs</h1>
             <p className="medium-body-copy">
               Full list of all the open opportunities at the amazing
-              organizations partnering with us to make THAT Wisconsin 2020
+              organizations partnering with us to make THAT Wisconsin 2021
               happen.
             </p>
             <ActionButtonRow>
@@ -184,12 +193,12 @@ const jobs = () => {
 
       <ContentSection>
         {filteredPartners.map(partner => (
-          <PartnerSection>
+          <PartnerSection key={partner.id}>
             <StyledPartnerLogoWithInfo partner={partner} alignment="center" />
             <Jobs>
               {_.sortBy(partner.jobListings, j => j.title.toLowerCase()).map(
                 job => (
-                  <JobListing job={job} partner={partner} />
+                  <JobListing job={job} partner={partner} key={job.id} />
                 ),
               )}
             </Jobs>


### PR DESCRIPTION
Styling and format handling for partner jobs

### Description
Adjusted styling of partner jobs and updated the job slug to use a `<pre>` instead of `<p>` for description.
