### PR TITLE
clean up and remove duplication from PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,59 +1,29 @@
-<!--- Provide a general summary of your changes in the Title above -->
-
 ### Description
+
 <!--- Describe your changes in detail -->
 
-Fixes #
-
-### Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
-
-### How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, tests ran to see how -->
-<!--- your change affects other areas of the code, etc. -->
-
+Fixes #<!--- corresponding issue number -->
 
 ### Screenshots (if appropriate):
 
 ### Types of changes
+
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaki<!--- Provide a general summary of your changes in the Title above -->
 
-### Description
-<!--- Describe your changes in detail -->
-
-### Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
-
-### How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, tests ran to see how -->
-<!--- your change affects other areas of the code, etc. -->
-*Browsers, sizes, devices... you know the drill*
-
-### Screenshots (if appropriate):
-
-### Types of changes
-<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+### How Has This Been Tested?
+
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+<!--- Browsers, sizes, devices... you know the drill -->
 
 ### Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] My code follows the code style of this project.
-- [ ] My change requires a change to the documentation.
-- [ ] I have updated the documentation accordingly.ng change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
-### Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have updated the documentation if neccessary.
-- [ ] I have updated the stories as neccessary.
-- [ ] I have updated the specs neccessary.
+
+- [ ] I have updated the documentation if necessary
+- [ ] I have updated the stories as necessary
+- [ ] I have updated the specs necessary


### PR DESCRIPTION
### Description
Removes the duplication in the PR template and cleans up some of the prompts.

Fixes (no corresponding issue)

### Motivation and Context
To make the PR process more informative and work better with THAT Community members who are contributing. 

### How Has This Been Tested?
Next person to open a PR is the winner. 

### Screenshots (if appropriate):
n/a

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] I have updated the documentation if necessary.
- [ ] I have updated the stories as necessary.
- [ ] I have updated the specs necessary.
