### PR TITLE
fix member social links

### DIFF
--- a/pages/member/[memberSlug].js
+++ b/pages/member/[memberSlug].js
@@ -189,7 +189,7 @@ const member = ({ slug, user, loading: loadingUser }) => {
         key => memberConstants.linkTypes[key] === item.linkType,
       );
       return {
-        [newKey]: item.url,
+        [newKey]: item,
       };
     });
 


### PR DESCRIPTION
### Description

Corrects issue where member social icons don't have associated URL. 

Test current site social links e.g. https://www.thatconference.com/member/yrodriguez, the links are not active as they component did not receive a proper object and was unable to get the URL. 

The SocialLinks component get's the url: 

```react
  return (
    <SocialLinksContainer className={className} rowOrColumn={flexDirection}>
      {Object.keys(socialLinks).map(key => {
        return (
          <SocialBlock size={size} className="social-block" key={key}>
            <StyledLink
              href={socialLinks[key].url}
              target="_blank"
              rel="noreferrer noopener"
              key={key}
              onClick={() => clickTracking(key)}
              size={size}
              ariaLabel={key}
            >
...
```

Fixes # n/a

### Types of changes

Corrects object created for socials which changed when description where added to social types (I believe)

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested other socials on site to verify there are no regressions from this correction. This fix is in the data object for the member's social links only.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation if necessary
- [ ] I have updated the stories as necessary
- [ ] I have updated the specs necessary
