### PR TITLE
add All Contributors section

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,111 @@
+{
+  "projectName": "that-website",
+  "projectOwner": "ThatConference",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "saragibby",
+      "name": "Sara Gibbons",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/82035?v=4",
+      "profile": "https://github.com/saragibby",
+      "contributions": [
+        "code",
+        "content",
+        "doc",
+        "review"
+      ]
+    },
+    {
+      "login": "csell5",
+      "name": "Clark Sell",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/772569?v=4",
+      "profile": "http://unspecified.io/",
+      "contributions": [
+        "code",
+        "maintenance",
+        "content"
+      ]
+    },
+    {
+      "login": "kburnell",
+      "name": "Keith Burnell",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/590291?v=4",
+      "profile": "http://www.dotnetdevdude.com/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "brettski",
+      "name": "Brett Slaski",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/473633?v=4",
+      "profile": "http://blog.brettski.com/",
+      "contributions": [
+        "infra",
+        "code",
+        "test",
+        "review"
+      ]
+    },
+    {
+      "login": "zaudtke",
+      "name": "Al",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1631560?v=4",
+      "profile": "https://github.com/zaudtke",
+      "contributions": [
+        "bug",
+        "test",
+        "code"
+      ]
+    },
+    {
+      "login": "astralbodies",
+      "name": "Aaron Douglas",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/373903?v=4",
+      "profile": "https://aaron.blog/",
+      "contributions": [
+        "test",
+        "bug"
+      ]
+    },
+    {
+      "login": "tsidel",
+      "name": "Jeana",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/194128?v=4",
+      "profile": "https://www.jeana.dev/",
+      "contributions": [
+        "test",
+        "code"
+      ]
+    },
+    {
+      "login": "GeekOnCoffee",
+      "name": "Andrew Hooker",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/240650?v=4",
+      "profile": "https://leanpub.com/os-support",
+      "contributions": [
+        "bug",
+        "code"
+      ]
+    },
+    {
+      "login": "mcookWI",
+      "name": "Mike",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/5367626?v=4",
+      "profile": "https://github.com/mcookWI",
+      "contributions": [
+        "test",
+        "bug",
+        "content"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Contributing
 
+[![GitHub issues open](https://img.shields.io/github/issues/thatconference/that-website.svg)](https://github.com/thatconference/that-website/issues) [![release](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/thatconference/that.us/issues)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 ### Table of Contents
 
 1. Types of contributions we are looking for
@@ -143,3 +147,32 @@ Example - Check out `samples/toggle-page.js`. Here is a sample page wrapped in `
 Go to: [http://localhost:3000/samples/toggle-page?feature=baconisgreat](http://localhost:3000/samples/toggle-page?feature=baconisgreat) and page will load.  
 Go to: [http://localhost:3000/samples/toggle-page?feature=baconisgood](http://localhost:3000/samples/toggle-page?feature=baconisgood), page not found  
 Go to: [http://localhost:3000/samples/toggle-page](http://localhost:3000/samples/toggle-page), page not found
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/saragibby"><img src="https://avatars1.githubusercontent.com/u/82035?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sara Gibbons</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=saragibby" title="Code">💻</a> <a href="#content-saragibby" title="Content">🖋</a> <a href="https://github.com/ThatConference/that-website/commits?author=saragibby" title="Documentation">📖</a> <a href="https://github.com/ThatConference/that-website/pulls?q=is%3Apr+reviewed-by%3Asaragibby" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="http://unspecified.io/"><img src="https://avatars1.githubusercontent.com/u/772569?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Clark Sell</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=csell5" title="Code">💻</a> <a href="#maintenance-csell5" title="Maintenance">🚧</a> <a href="#content-csell5" title="Content">🖋</a></td>
+    <td align="center"><a href="http://www.dotnetdevdude.com/"><img src="https://avatars1.githubusercontent.com/u/590291?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Keith Burnell</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=kburnell" title="Code">💻</a></td>
+    <td align="center"><a href="http://blog.brettski.com/"><img src="https://avatars3.githubusercontent.com/u/473633?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Brett Slaski</b></sub></a><br /><a href="#infra-brettski" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/ThatConference/that-website/commits?author=brettski" title="Code">💻</a> <a href="https://github.com/ThatConference/that-website/commits?author=brettski" title="Tests">⚠️</a> <a href="https://github.com/ThatConference/that-website/pulls?q=is%3Apr+reviewed-by%3Abrettski" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://github.com/zaudtke"><img src="https://avatars1.githubusercontent.com/u/1631560?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Al</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/issues?q=author%3Azaudtke" title="Bug reports">🐛</a> <a href="https://github.com/ThatConference/that-website/commits?author=zaudtke" title="Tests">⚠️</a> <a href="https://github.com/ThatConference/that-website/commits?author=zaudtke" title="Code">💻</a></td>
+    <td align="center"><a href="https://aaron.blog/"><img src="https://avatars1.githubusercontent.com/u/373903?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Aaron Douglas</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=astralbodies" title="Tests">⚠️</a> <a href="https://github.com/ThatConference/that-website/issues?q=author%3Aastralbodies" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://www.jeana.dev/"><img src="https://avatars2.githubusercontent.com/u/194128?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jeana</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=tsidel" title="Tests">⚠️</a> <a href="https://github.com/ThatConference/that-website/commits?author=tsidel" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://leanpub.com/os-support"><img src="https://avatars3.githubusercontent.com/u/240650?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Andrew Hooker</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/issues?q=author%3AGeekOnCoffee" title="Bug reports">🐛</a> <a href="https://github.com/ThatConference/that-website/commits?author=GeekOnCoffee" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/mcookWI"><img src="https://avatars0.githubusercontent.com/u/5367626?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike</b></sub></a><br /><a href="https://github.com/ThatConference/that-website/commits?author=mcookWI" title="Tests">⚠️</a> <a href="https://github.com/ThatConference/that-website/issues?q=author%3AmcookWI" title="Bug reports">🐛</a> <a href="#content-mcookWI" title="Content">🖋</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/package-lock.json
+++ b/package-lock.json
@@ -4111,6 +4111,205 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
+    "all-contributors-cli": {
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/all-contributors-cli/-/all-contributors-cli-6.16.1.tgz",
+      "integrity": "sha512-8Hu4vHwW8VF28EBmgCpyfleOG8jCU0RB5sEFMuHzIKy8lUidV2Qo/1GfQ1b78ekB4mYMgdMvfDJd5IKtfzUeGg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.6",
+        "async": "^3.0.1",
+        "chalk": "^4.0.0",
+        "didyoumean": "^1.2.1",
+        "inquirer": "^7.0.4",
+        "json-fixer": "^1.5.1",
+        "lodash": "^4.11.2",
+        "pify": "^5.0.0",
+        "request": "^2.72.0",
+        "yargs": "^15.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "ally.js": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
@@ -4585,6 +4784,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
       "dev": true
     },
     "async-each": {
@@ -7246,6 +7451,12 @@
           "dev": true
         }
       }
+    },
+    "didyoumean": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+      "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+      "dev": true
     },
     "diff-sequences": {
       "version": "26.0.0",
@@ -12887,6 +13098,78 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
+    "json-fixer": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/json-fixer/-/json-fixer-1.5.3.tgz",
+      "integrity": "sha512-w05yQbFsIYy4j6JBWl5qACgkrYqRI6e+BnOKZkY6EpwpyWqESNtcNgwba8clhoECepE2DpsNAP15IMzSDCWWJA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "chalk": "^4.1.0",
+        "pegjs": "^0.10.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -14734,6 +15017,12 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@storybook/addon-links": "^5.3.19",
     "@storybook/addons": "^5.3.19",
     "@storybook/react": "^5.3.19",
+    "all-contributors-cli": "^6.16.1",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
Allows us to showcase contributors. Two methods to add new contributors
The All Contributors bot: https://allcontributors.org/docs/en/bot/usage
or
the All Contributors CLI which is added as a dev dependency (which is good for adding multiple): 
https://allcontributors.org/docs/en/cli/usage#all-contributors-add

