### PR TITLE
fix(Issue-571): Updated partners slug page to use <pre> tags for about and short description.

### DIFF
--- a/components/shared/StandardStyles.js
+++ b/components/shared/StandardStyles.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { below } from '../../utilities';
 
 /** * BEGIN: Page elements shared in layouts ** */

--- a/components/shared/StandardStyles.js
+++ b/components/shared/StandardStyles.js
@@ -29,7 +29,7 @@ export const InnerPage = styled.div`
 `;
 /** * END: Page elements shared in layouts ** */
 
-const ParagraphAndPreSharedStyles = css`
+export const StyledP = styled.p`
   padding-right: 1rem;
   margin-top: 0;
   font-weight: 200;
@@ -40,12 +40,17 @@ const ParagraphAndPreSharedStyles = css`
   `};
 `;
 
-export const StyledP = styled.p`
-  ${ParagraphAndPreSharedStyles}
-`;
-
 export const StyledPre = styled.pre`
-  ${ParagraphAndPreSharedStyles}
+  padding-right: 1rem;
+  margin-top: 0;
+  font-weight: 200;
+  line-height: 1.6;
+  font-size: 1.5rem;
+  height: auto;
+
+  ${below.med`
+    margin-top: 0;
+  `};
 `;
 
 export const ActionButtonRow = styled.div`

--- a/components/shared/StandardStyles.js
+++ b/components/shared/StandardStyles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { below } from '../../utilities';
 
 /** * BEGIN: Page elements shared in layouts ** */
@@ -29,7 +29,7 @@ export const InnerPage = styled.div`
 `;
 /** * END: Page elements shared in layouts ** */
 
-export const StyledP = styled.p`
+const ParagraphAndPreSharedStyles = css`
   padding-right: 1rem;
   margin-top: 0;
   font-weight: 200;
@@ -40,16 +40,12 @@ export const StyledP = styled.p`
   `};
 `;
 
-export const StyledPre = styled.pre`
-  padding-right: 1rem;
-  margin-top: 0;
-  font-weight: 200;
-  line-height: 1.6;
-  font-size: 1.5rem;
+export const StyledP = styled.p`
+  ${ParagraphAndPreSharedStyles}
+`;
 
-  ${below.med`
-    margin-top: 0;
-  `};
+export const StyledPre = styled.pre`
+  ${ParagraphAndPreSharedStyles}
 `;
 
 export const ActionButtonRow = styled.div`

--- a/pages/partner/[slug].js
+++ b/pages/partner/[slug].js
@@ -18,6 +18,7 @@ import LinkButton from '../../components/shared/LinkButton/LinkButton';
 import {
   ActionButtonRow,
   StyledP,
+  StyledPre,
 } from '../../components/shared/StandardStyles';
 
 import { below, gridRepeat } from '../../utilities';
@@ -102,6 +103,11 @@ const JobDescription = styled.p`
   ${below.med`
     margin-top: 0;
   `};
+`;
+
+const PartnerStyledPre = styled(StyledPre)`
+  font-size: 1.5rem;
+  height: auto;
 `;
 
 const GoalsList = styled.ul`
@@ -296,7 +302,7 @@ function PartnerDetail() {
       <PartnerDetailSubHeading>
         About {partner.companyName}
       </PartnerDetailSubHeading>
-      <StyledP>{partner.aboutUs}</StyledP>
+      <PartnerStyledPre>{partner.aboutUs}</PartnerStyledPre>
       <StyledP>{getCityState({ partner })}</StyledP>
     </>
   );
@@ -356,7 +362,7 @@ function PartnerDetail() {
             </Speaker>
             <SessionDetail>
               <Title>{session.title}</Title>
-              <StyledP>{session.shortDescription}</StyledP>
+              <PartnerStyledPre>{session.shortDescription}</PartnerStyledPre>
               {/* Uncomment once sessionb view is wired up */}
               {/* <ViewLink href="/">
                   <span>View Session</span>

--- a/pages/partner/[slug].js
+++ b/pages/partner/[slug].js
@@ -105,11 +105,6 @@ const JobDescription = styled.p`
   `};
 `;
 
-const PartnerStyledPre = styled(StyledPre)`
-  font-size: 1.5rem;
-  height: auto;
-`;
-
 const GoalsList = styled.ul`
   padding-inline-start: 2rem;
   font-weight: 200;
@@ -302,7 +297,7 @@ function PartnerDetail() {
       <PartnerDetailSubHeading>
         About {partner.companyName}
       </PartnerDetailSubHeading>
-      <PartnerStyledPre>{partner.aboutUs}</PartnerStyledPre>
+      <StyledPre>{partner.aboutUs}</StyledPre>
       <StyledP>{getCityState({ partner })}</StyledP>
     </>
   );
@@ -362,7 +357,7 @@ function PartnerDetail() {
             </Speaker>
             <SessionDetail>
               <Title>{session.title}</Title>
-              <PartnerStyledPre>{session.shortDescription}</PartnerStyledPre>
+              <StyledPre>{session.shortDescription}</StyledPre>
               {/* Uncomment once sessionb view is wired up */}
               {/* <ViewLink href="/">
                   <span>View Session</span>


### PR DESCRIPTION
### Description

- Updated partners slug page to use `<pre>` instead of `<p>` for about us and short description so basic formatting is preserved.

- While ensuring there was a shared global pre style I noticed that the shared pre and paragraph styles where duplicated so I refactored to use a styled css to reduce redundancy.

Fixes #571 

### Screenshots (if appropriate):
<img width="781" alt="Issue571_After" src="https://user-images.githubusercontent.com/590291/88381886-f479b380-cd6c-11ea-93ee-0e04c90aeed4.png">

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
I tested this by viewing the partner mentioned in the bug, /partner/do-it-best-corp as well as other partners I knew had data such as, /partner/navitus-health-solutions and /partner/NVISIA to ensure all looked good.

I also confirmed other views that use the shared pre style such as, /wi/2021/jobs, where not impacted negatively by this change.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [N/A] I have updated the documentation if necessary
- [N/A] I have updated the stories as necessary
- [N/A] I have updated the specs necessary
