### PR TITLE
regression. missed data path from events schema update

### DIFF
--- a/pages/wi/2021/partners.js
+++ b/pages/wi/2021/partners.js
@@ -180,7 +180,7 @@ const partnerListing = () => {
             </p>
             <ActionButtonRow>
               <LinkButton
-                href={`/${data.events.event.slug}/become-a-partner`}
+                href={`/${data.events.event.get.slug}/become-a-partner`}
                 label="Become a Partner"
                 color="thatBlue"
                 borderColor="thatBlue"


### PR DESCRIPTION
regression from pr thatconference/that-api-events#100

Data path not updated causing `undefined` result for button path. 