### PR TITLE
add search to partners page

### DIFF
--- a/components/shared/StandardStyles.js
+++ b/components/shared/StandardStyles.js
@@ -79,11 +79,8 @@ export const ActionButtonRow = styled.div`
 export const HeroGraphicDiv = styled.div`
   min-width: 45rem;
   margin: 0;
-
-  ${below.larger`
-    display: flex;
-    justify-content: center;
-  `};
+  display: flex;
+  justify-content: center;
 
   ${below.med`
     min-width: unset;

--- a/pages/partners.js
+++ b/pages/partners.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 import { useQuery } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';
 import { Grid, Cell } from 'styled-css-grid';
 import { NextSeo } from 'next-seo';
-import _ from 'lodash';
+import { sortBy } from 'lodash';
 import ContentSection from '../components/shared/ContentSection';
 import ImageContainer from '../components/shared/ImageContainer';
 import LinkButton from '../components/shared/LinkButton/LinkButton';
@@ -28,8 +28,6 @@ const GET_ALL_PARTNERS = gql`
 
 const HighlightImage = styled.img`
   max-height: 30rem;
-  position: absolute;
-  top: 3rem;
   object-fit: contain;
 
   ${below.small`
@@ -47,6 +45,7 @@ const PaddedImageContainer = styled(ImageContainer)`
   margin: 1rem 0.5rem;
   height: 13rem;
   width: 17rem;
+  background-color: ${({ theme }) => theme.colors.white};
 
   ${below.small`
     margin: 0.5rem auto;
@@ -68,8 +67,40 @@ const Image = styled.img`
   }
 `;
 
+const PartnerSearchBox = styled.div`
+  min-width: 40rem;
+  margin: auto;
+  max-width: 80rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding: 2rem;
+`;
+
+const PartnerSearchTitle = styled.h5`
+  text-align: center;
+  margin-bottom: 0;
+  margin-top: 1rem;
+`;
+
+const PartnerSearchInput = styled.input`
+  width: 40rem;
+`;
+
 const partners = () => {
+  const [searchText, setSearchText] = useState('');
   const { loading, data } = useQuery(GET_ALL_PARTNERS);
+
+  const partnerMatchSearch = partner =>
+    partner.companyName.toLowerCase().includes(searchText.toLowerCase());
+
+  const searchedPartners = () => {
+    if (loading) return [];
+    return searchText.length > 0
+      ? data.partners.all.filter(partnerMatchSearch)
+      : data.partners.all;
+  };
 
   return (
     <>
@@ -107,8 +138,19 @@ const partners = () => {
           </HeroGraphicDiv>
         </Grid>
       </ContentSection>
-
-      <ContentSection>
+      <ContentSection backgroundColor="offWhite" hasTrees="true">
+        <PartnerSearchBox>
+          <PartnerSearchTitle>
+            Looking to connect with a THAT Partner? Awesome! Let us help...
+          </PartnerSearchTitle>
+          <PartnerSearchInput
+            id="search-partners"
+            type="text"
+            name="searchPartnersText"
+            placeholder="Name of partner you are searching for"
+            onChange={e => setSearchText(e.target.value)}
+          />
+        </PartnerSearchBox>
         {loading && (
           <div style={{ textAlign: 'center' }}>
             <SkeletonLoader />
@@ -116,7 +158,7 @@ const partners = () => {
         )}
         {!loading && (
           <Grid columns={gridRepeat.xxsmall} alignContent="center">
-            {_.sortBy(data.partners.all, p => p.companyName.toLowerCase()).map(
+            {sortBy(searchedPartners(), p => p.companyName.toLowerCase()).map(
               partner => {
                 return (
                   <PaddedImageContainer key={partner.id}>

--- a/pages/partners.js
+++ b/pages/partners.js
@@ -42,7 +42,7 @@ const HighlightImage = styled.img`
 `;
 
 const PaddedImageContainer = styled(ImageContainer)`
-  margin: 1rem 0.5rem;
+  margin: 1rem 1rem;
   height: 13rem;
   width: 17rem;
   background-color: ${({ theme }) => theme.colors.white};
@@ -86,6 +86,13 @@ const PartnerSearchTitle = styled.h5`
 
 const PartnerSearchInput = styled.input`
   width: 40rem;
+`;
+
+const PartnerContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin: auto;
+  justify-content: center;
 `;
 
 const partners = () => {
@@ -157,7 +164,7 @@ const partners = () => {
           </div>
         )}
         {!loading && (
-          <Grid columns={gridRepeat.xxsmall} alignContent="center">
+          <PartnerContainer>
             {sortBy(searchedPartners(), p => p.companyName.toLowerCase()).map(
               partner => {
                 return (
@@ -177,7 +184,7 @@ const partners = () => {
                 );
               },
             )}
-          </Grid>
+          </PartnerContainer>
         )}
       </ContentSection>
     </>

--- a/styles/globalStyle.js
+++ b/styles/globalStyle.js
@@ -171,70 +171,64 @@ const GlobalStyle = createGlobalStyle`
     text-align: right;
   }
 
-  form {
-    input {
-      padding: 1rem;
+
+  input {
+    padding: 1rem;
+  }
+
+  input, textarea {
+    margin-top: 0.75rem;
+    border: 1px solid ${({ theme }) => theme.colors.mediumGray};
+    background-color: ${({ theme }) => theme.colors.mediumLightGray};
+
+    &::-webkit-input-placeholder {
+      /* Chrome/Opera/Safari */
+      color: ${({ theme }) => theme.colors.mediumGray};
+    }
+    &::-moz-placeholder {
+      /* Firefox 19+ */
+      color: ${({ theme }) => theme.colors.mediumGray};
+    }
+    &:-ms-input-placeholder {
+      /* IE 10+ */
+      color: ${({ theme }) => theme.colors.mediumGray};
+    }
+    &:-moz-placeholder {
+      /* Firefox 18- */
+      color: ${({ theme }) => theme.colors.mediumGray};
     }
 
-    &.input-form {
+    &:disabled {
+      background-color: ${({ theme }) => theme.colors.mediumLightGray};
+    }
 
-      input, textarea {
-        margin-top: 0.75rem;
-        border: 1px solid ${({ theme }) => theme.colors.mediumGray};
-        background-color: ${({ theme }) => theme.colors.mediumLightGray};
+    &:focus {
+      outline: ${({ theme }) => theme.colors.thatBlue} auto 1px;
+    }
 
-        &::-webkit-input-placeholder {
-          /* Chrome/Opera/Safari */
-          color: ${({ theme }) => theme.colors.mediumGray};
-        }
-        &::-moz-placeholder {
-          /* Firefox 19+ */
-          color: ${({ theme }) => theme.colors.mediumGray};
-        }
-        &:-ms-input-placeholder {
-          /* IE 10+ */
-          color: ${({ theme }) => theme.colors.mediumGray};
-        }
-        &:-moz-placeholder {
-          /* Firefox 18- */
-          color: ${({ theme }) => theme.colors.mediumGray};
-        }
+    &.invalid {
+      border-color: ${({ theme }) => theme.colors.danger};
 
-        &:disabled {
-          background-color: ${({ theme }) => theme.colors.mediumLightGray};
-        }
-
-        &:focus {
-          outline: ${({ theme }) => theme.colors.thatBlue} auto 1px;
-        }
-
-        &.invalid {
-          border-color: ${({ theme }) => theme.colors.danger};
-
-          &:focus {
-            outline-offset: 0;
-            outline: unset;
-            border-color: ${({ theme }) => theme.colors.danger};
-            box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.55);
-          }
-        } //invalid
-
-      } //input, textarea
-
-      .react-select-container.invalid {
-        border: 1px solid red;
-
-        &:focus {
-            outline-offset: 0;
-            outline: unset;
-            border-color: ${({ theme }) => theme.colors.danger};
-            box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.55);
-          }
+      &:focus {
+        outline-offset: 0;
+        outline: unset;
+        border-color: ${({ theme }) => theme.colors.danger};
+        box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.55);
       }
+    } //invalid
 
-    } //input-form
+  } //input, textarea
 
-  } //form
+  .react-select-container.invalid {
+    border: 1px solid red;
+
+    &:focus {
+        outline-offset: 0;
+        outline: unset;
+        border-color: ${({ theme }) => theme.colors.danger};
+        box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.55);
+      }
+  }
 
   @-webkit-keyframes BackgroundAnimation {
     0%{background-position:0% 50%}


### PR DESCRIPTION
### Description
Adds search box on partners bag that searches partners `companyName` for a match to search text entered. Then filters the partner list to only display matching partners.

Fixes #467 

### Screenshots (if appropriate):
![All_Partners_-_THAT_Conference](https://user-images.githubusercontent.com/82035/96904799-9345a700-1465-11eb-82d8-a5fcc4cb7dfb.png)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested through running app locally within Brave, Chrome and Safari on varying sizes. Also, clicked through pages rendering a graphic in top section since I updated the styles for that graphic.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation if necessary
- [ ] I have updated the stories as necessary
- [ ] I have updated the specs necessary
