### PR TITLE
add placeholder image constant; add to partner detail

### DIFF
--- a/components/PartnerDetail/MainLogoSection.js
+++ b/components/PartnerDetail/MainLogoSection.js
@@ -6,7 +6,7 @@ import { Grid, Cell } from 'styled-css-grid';
 import ContentSection from '../shared/ContentSection';
 import PartnerLogoWithInfo from '../shared/PartnerLogoWithInfo';
 import PartnerDetailSubHeading from './PartnerDetailSubHeading';
-import { below, gridRepeat } from '../../utilities';
+import { below, gridRepeat, placeHolderImageUrl } from '../../utilities';
 
 const LogoMemberSection = styled.div`
   display: flex;
@@ -65,7 +65,7 @@ const renderMember = member => {
   return (
     <Member key={member.id}>
       <Imgix
-        src={member.profileImage}
+        src={member.profileImage || placeHolderImageUrl}
         width={60}
         height={60}
         imgixParams={{ mask: 'ellipse', fit: 'facearea', facepad: 4 }}

--- a/components/shared/RoundImage.js
+++ b/components/shared/RoundImage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import Imgix from 'react-imgix';
+import { placeHolderImageUrl } from '../../utilities';
 
 const AccentLine = styled.span`
   height: ${({ size }) => size}rem;
@@ -16,9 +17,7 @@ const RoundImage = ({ className, imageUrl, size, showAccentLine, alt }) => {
     <>
       <Imgix
         className={className}
-        src={
-          imageUrl || 'https://images.that.tech/members/person-placeholder.jpg'
-        }
+        src={imageUrl || placeHolderImageUrl}
         width={intsize}
         height={intsize}
         imgixParams={{

--- a/pages/member/[memberSlug].js
+++ b/pages/member/[memberSlug].js
@@ -8,14 +8,17 @@ import { gql } from 'apollo-boost';
 import Imgix from 'react-imgix';
 import Error from '../_error';
 import LoadingIndicator from '../../components/shared/LoadingIndicator';
-import { below, memberConstants, socialConstants } from '../../utilities';
+import {
+  below,
+  memberConstants,
+  placeHolderImageUrl,
+  socialConstants,
+} from '../../utilities';
 import ContentSection from '../../components/shared/ContentSection';
 import RoundImage from '../../components/shared/RoundImage';
 import ThatLink from '../../components/shared/ThatLink';
 import SocialLinks from '../../components/shared/SocialLinks';
 import Icon from '../../components/shared/Icon';
-
-const DEFAULT_IMAGE = 'https://images.that.tech/members/person-placeholder.jpg';
 
 const StyledGrid = styled(Grid)`
   grid-gap: 2.5rem;
@@ -254,7 +257,7 @@ const member = ({ slug, user, loading: loadingUser }) => {
             )}
             {!profileImage && (
               <RoundImage
-                imageUrl={DEFAULT_IMAGE}
+                imageUrl={placeHolderImageUrl}
                 size="250"
                 showAccentLine={false}
               />

--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -1,6 +1,9 @@
 import * as Yup from 'yup';
 import { RegularExpressions } from './validation';
 
+export const placeHolderImageUrl =
+  'https://images.that.tech/members/person-placeholder.jpg';
+
 // eslint-disable-next-line import/prefer-default-export
 export const sessionConstants = {
   SessionFors: [


### PR DESCRIPTION
### Description

Use the member placeholder image on the partner detail page for instances when the partner member does not yet have a profile image uploaded.

Also, moves the person placeholder image to constants. 

Fixes #581

### Screenshots (if appropriate):
Example partner that has a member without a profile image:
![image](https://user-images.githubusercontent.com/82035/96913018-191b1f80-1471-11eb-91a3-e9ac7b859231.png)


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Running app locally checking "Do It Best Corp" who currently has member without a profile image.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation if necessary
- [ ] I have updated the stories as necessary
- [ ] I have updated the specs necessary
