### PR TITLE
add apply now link to job page when exists

### DIFF
--- a/components/shared/SocialLinks.js
+++ b/components/shared/SocialLinks.js
@@ -14,6 +14,7 @@ const SocialLinksContainer = styled.div`
 
 const SocialBlock = styled.div`
   width: ${props => props.size};
+  margin: 0 0.25rem;
 `;
 
 const StyledLink = styled.a`

--- a/pages/partner/[slug]/job/[jobSlug].js
+++ b/pages/partner/[slug]/job/[jobSlug].js
@@ -7,7 +7,10 @@ import { NextSeo, JobPostingJsonLd } from 'next-seo';
 import LinkButton from '../../../../components/shared/LinkButton/LinkButton';
 import ContentSection from '../../../../components/shared/ContentSection';
 import LoadingIndicator from '../../../../components/shared/LoadingIndicator';
-import { ActionButtonRow } from '../../../../components/shared/StandardStyles';
+import {
+  ActionButtonRow,
+  StyledPre,
+} from '../../../../components/shared/StandardStyles';
 import PartnerLogoWithInfo from '../../../../components/shared/PartnerLogoWithInfo';
 import { below, above } from '../../../../utilities';
 
@@ -39,6 +42,7 @@ const GET_PARTNER_JOB = gql`
           remote
           role
           featured
+          applyNowLink
         }
       }
     }
@@ -123,7 +127,7 @@ const StyledPartnerLogoWithInfo = styled(PartnerLogoWithInfo)`
 
 const AttributesRow = styled.div`
   display: flex;
-  margin-top: 1rem;
+  margin-bottom: 2rem;
 `;
 
 const AttributeTag = styled.div`
@@ -141,6 +145,13 @@ const AttributeTag = styled.div`
     font-weight: 700;
     vertical-align: middle;
   }
+`;
+
+const ApplyNowLinkButton = styled(LinkButton)`
+  width: 25rem;
+  min-width: 25rem;
+  margin-top: -1rem;
+  margin-bottom: 3rem;
 `;
 
 const JobNotFound = ({ slug }) => (
@@ -249,7 +260,21 @@ const jobDetail = () => {
                 </AttributeTag>
               )}
             </AttributesRow>
-            <pre className="medium-body-copy">{job.description}</pre>
+            {job.applyNowLink && (
+              <ApplyNowLinkButton
+                href={job.applyNowLink}
+                label="Apply Now"
+                color="thatBlue"
+                borderColor="thatBlue"
+                className="stretch-sm"
+                hoverBorderColor="thatBlue"
+                hoverColor="white"
+                hoverBackgroundColor="thatBlue"
+                target="blank"
+                rel="noopener"
+              />
+            )}
+            <StyledPre>{job.description}</StyledPre>
             <ActionButtonRow>
               <LinkButton
                 href={`/partner/${partner.slug}`}
@@ -283,6 +308,7 @@ const jobDetail = () => {
                 hoverBackgroundColor="thatBlue"
                 isLocal={false}
                 target="blank"
+                rel="noopener"
               />
             </ActionButtonRow>
           </SideDetail>


### PR DESCRIPTION
### Description

Adds an "Apply Now" button to the job detail page when the job has an `applyNowLink` set for it.
Also, updating formatting of text to match other parter and job areas of site.

Fixes #584

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/82035/96942458-31a42d80-14a3-11eb-8ea2-191a255d670b.png)


### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Marked as new feature as this functionality was never part of original design, and therefore never a broken. Was simple not yet implemented. 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested through the existing jobs in dB, both with and without `applyNowLink` values.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation if necessary
- [ ] I have updated the stories as necessary
- [ ] I have updated the specs necessary
