### PR TITLE
fixes http 502 running in vercel on bad route

### DIFF
--- a/lib/sentry.js
+++ b/lib/sentry.js
@@ -68,7 +68,7 @@ export function captureException(err, ctx) {
           scope.setExtra('query', req.query);
 
           // On server-side we take session cookie directly from request
-          if (req.cookies.sid) {
+          if (req.cookies && req.cookies.sid) {
             scope.setUser({ id: req.cookies.sid });
           }
         }


### PR DESCRIPTION
Corrects the error happening when an unknown route is used. The code was blowing up in `sentry.js` trying to access a property on a property which didn't exist. 

Though this fixes the hard error, the resulting error page isn't want we want and will still need to be corrected in the future. Preferably someone who knows a bit more about Next.js. This is being tracked in issue #610 